### PR TITLE
Trying to cleanup result and debug printing.

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,11 @@ import (
 	"github.com/drone/drone-go/template"
 )
 
+const (
+	respFormat      = "Webhook %d\n  URL: %s\n  RESPONSE STATUS: %s\n  RESPONSE BODY: %s\n"
+	debugRespFormat = "Webhook %d\n  URL: %s\n  METHOD: %s\n  HEADERS: %s\n  REQUEST BODY: %s\n  RESPONSE STATUS: %s\n  RESPONSE BODY: %s\n"
+)
+
 var (
 	build     string
 	buildDate string
@@ -122,7 +127,7 @@ func main() {
 
 			if vargs.Debug {
 				fmt.Printf(
-					"Webhook %d\n  URL: %s\n  METHOD: %s\n  HEADERS: %s\n  REQUEST BODY: %s\n  RESPONSE STATUS: %s\n  RESPONSE BODY: %s\n",
+					debugRespFormat,
 					i+1,
 					req.URL,
 					req.Method,
@@ -133,7 +138,7 @@ func main() {
 				)
 			} else {
 				fmt.Printf(
-					"Webhook %d\n  URL: %s\n  RESPONSE STATUS: %s\n  RESPONSE BODY: %s\n",
+					respFormat,
 					i+1,
 					req.URL,
 					resp.Status,

--- a/types.go
+++ b/types.go
@@ -1,5 +1,6 @@
 package main
 
+// Params represents the valid paramenter options for the webhook plugin.
 type Params struct {
 	Urls        []string          `json:"urls"`
 	Debug       bool              `json:"debug"`
@@ -10,6 +11,7 @@ type Params struct {
 	ContentType string            `json:"content_type"`
 }
 
+// Auth represents a basic HTTP authentication username and password.
 type Auth struct {
 	Username string `json:"username"`
 	Password string `json:"password"`


### PR DESCRIPTION
This PR is trying to make the code for printing the webhook result and debug result less ugly based on [this conversation](https://github.com/drone-plugins/drone-webhook/pull/6#issuecomment-168429883).  If you have a better idea, help please! 

Also as a side note I noticed that much of the overall plugin code base is using `Urls` instead of `URLs`.  You can find an example [here](https://github.com/drone-plugins/drone-webhook/blob/master/types.go#L4).  The go standard library uses `URL` or `url`, [example here](https://golang.org/pkg/net/url/#URL).  They also mention it as an example in [CodeReviewComments here](https://github.com/golang/go/wiki/CodeReviewComments#initialisms).  I know I am probably bordering on being WAY to picky and annoying, but just thought I would ask about it.