### PR TITLE
Changing Urls to URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	// and content_type values will be applied to
 	// every webhook request.
 
-	for i, rawurl := range vargs.Urls {
+	for i, rawurl := range vargs.URLs {
 		uri, err := url.Parse(rawurl)
 
 		if err != nil {

--- a/types.go
+++ b/types.go
@@ -2,7 +2,7 @@ package main
 
 // Params represents the valid paramenter options for the webhook plugin.
 type Params struct {
-	Urls        []string          `json:"urls"`
+	URLs        []string          `json:"urls"`
 	Debug       bool              `json:"debug"`
 	Auth        Auth              `json:"auth"`
 	Headers     map[string]string `json:"header"`


### PR DESCRIPTION
I noticed that much of the overall plugin code base is using `Urls` instead of `URLs`.  You can find an example [here](https://github.com/drone-plugins/drone-webhook/blob/master/types.go#L4).  The go standard library uses `URL` or `url`, [example here](https://golang.org/pkg/net/url/#URL).  They also mention it as an example in [CodeReviewComments](https://github.com/golang/go/wiki/CodeReviewComments#initialisms).  I know this is just a little nit. 