### PR TITLE
only show URL Host and not complete URL in normal mode

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -163,7 +163,7 @@ func (p Plugin) Exec() error {
 				fmt.Printf(
 					respFormat,
 					i+1,
-					req.URL,
+					req.URL.Host,
 					resp.Status,
 					string(body),
 				)


### PR DESCRIPTION
A possible method to fix #28 
It will now show only the Hostname e.g. drone.io insteat of the whole url. if you need the whole url for debuging, the debbuging mode willl show it after all.