### PR TITLE
Introduce Valid Response Codes setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker run --rm \
   -e PLUGIN_HEADERS="HEADER1=value1" \
   -e PLUGIN_USERNAME=drone \
   -e PLUGIN_PASSWORD=password \
-  -e PLUGIN_VALID_RESPONSE_CODES="200 201 202 404" \
+  -e PLUGIN_VALID_RESPONSE_CODES="200,202,404" \
   -e DRONE_REPO_OWNER=octocat \
   -e DRONE_REPO_NAME=hello-world \
   -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker run --rm \
   -e PLUGIN_HEADERS="HEADER1=value1" \
   -e PLUGIN_USERNAME=drone \
   -e PLUGIN_PASSWORD=password \
+  -e PLUGIN_VALID_RESPONSE_CODES="200 201 202 404" \
   -e DRONE_REPO_OWNER=octocat \
   -e DRONE_REPO_NAME=hello-world \
   -e DRONE_COMMIT_SHA=7fd1a60b01f91b314f59955a4e4d4e80d8edf11d \

--- a/main.go
+++ b/main.go
@@ -57,6 +57,11 @@ func main() {
 			Usage:  "list of urls to perform the action on",
 			EnvVar: "PLUGIN_URLS,WEBHOOK_URLS",
 		},
+		cli.IntSliceFlag{
+			Name:   "valid_response_codes",
+			Usage:  "list of response codes that are valid",
+			EnvVar: "PLUGIN_VALID_RESPONSE_CODES",
+		},
 		cli.BoolFlag{
 			Name:   "debug",
 			Usage:  "enable debug information",
@@ -184,6 +189,7 @@ func run(c *cli.Context) error {
 			Template:    c.String("template"),
 			Headers:     c.StringSlice("headers"),
 			URLs:        c.StringSlice("urls"),
+			ValidCodes:  c.IntSlice("valid_response_codes"),
 			Debug:       c.Bool("debug"),
 			SkipVerify:  c.Bool("skip-verify"),
 		},

--- a/main.go
+++ b/main.go
@@ -58,8 +58,8 @@ func main() {
 			EnvVar: "PLUGIN_URLS,WEBHOOK_URLS",
 		},
 		cli.IntSliceFlag{
-			Name:   "valid_response_codes",
-			Usage:  "list of response codes that are valid",
+			Name:   "valid-response-codes",
+			Usage:  "list of valid http response codes",
 			EnvVar: "PLUGIN_VALID_RESPONSE_CODES",
 		},
 		cli.BoolFlag{
@@ -189,7 +189,7 @@ func run(c *cli.Context) error {
 			Template:    c.String("template"),
 			Headers:     c.StringSlice("headers"),
 			URLs:        c.StringSlice("urls"),
-			ValidCodes:  c.IntSlice("valid_response_codes"),
+			ValidCodes:  c.IntSlice("valid-response-codes"),
 			Debug:       c.Bool("debug"),
 			SkipVerify:  c.Bool("skip-verify"),
 		},

--- a/plugin.go
+++ b/plugin.go
@@ -140,22 +140,6 @@ func (p Plugin) Exec() error {
 			return err
 		}
 
-		// Function checks if int is in slice of ints
-		f := func(s []int, e int) bool {
-			for _, a := range s {
-				if a == e {
-					return true
-				}
-			}
-			return false
-		}
-
-		if len(p.Config.ValidCodes) > 0 && !f(p.Config.ValidCodes, resp.StatusCode) {
-			err := fmt.Errorf("Response code %d not found among valid response codes", resp.StatusCode)
-			fmt.Printf("Error: %s\n", err)
-			return err
-		}
-
 		defer resp.Body.Close()
 
 		if p.Config.Debug || resp.StatusCode >= http.StatusBadRequest {
@@ -186,6 +170,23 @@ func (p Plugin) Exec() error {
 				)
 			}
 		}
+
+		// Function checks if int is in slice of ints
+		f := func(s []int, e int) bool {
+			for _, a := range s {
+				if a == e {
+					return true
+				}
+			}
+			return false
+		}
+
+		if len(p.Config.ValidCodes) > 0 && !f(p.Config.ValidCodes, resp.StatusCode) {
+			err := fmt.Errorf("Response code %d not found among valid response codes", resp.StatusCode)
+			fmt.Printf("Error: %s\n", err)
+			return err
+		}
+
 	}
 
 	return nil

--- a/plugin.go
+++ b/plugin.go
@@ -60,15 +60,6 @@ type (
 	}
 )
 
-func contains(s []int, e int) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func (p Plugin) Exec() error {
 	var (
 		buf bytes.Buffer
@@ -149,7 +140,17 @@ func (p Plugin) Exec() error {
 			return err
 		}
 
-		if len(p.Config.ValidCodes) > 0 && !contains(p.Config.ValidCodes, resp.StatusCode) {
+		// Function checks if int is in slice of ints
+		f := func(s []int, e int) bool {
+			for _, a := range s {
+				if a == e {
+					return true
+				}
+			}
+			return false
+		}
+
+		if len(p.Config.ValidCodes) > 0 && !f(p.Config.ValidCodes, resp.StatusCode) {
 			err := fmt.Errorf("Response code %d not found among valid response codes", resp.StatusCode)
 			fmt.Printf("Error: %s\n", err)
 			return err

--- a/plugin.go
+++ b/plugin.go
@@ -171,23 +171,21 @@ func (p Plugin) Exec() error {
 			}
 		}
 
-		// Function checks if int is in slice of ints
-		f := func(s []int, e int) bool {
-			for _, a := range s {
-				if a == e {
-					return true
-				}
-			}
-			return false
-		}
-
-		if len(p.Config.ValidCodes) > 0 && !f(p.Config.ValidCodes, resp.StatusCode) {
-			err := fmt.Errorf("Response code %d not found among valid response codes", resp.StatusCode)
-			fmt.Printf("Error: %s\n", err)
-			return err
+		if len(p.Config.ValidCodes) > 0 && !intInSlice(p.Config.ValidCodes, resp.StatusCode) {
+			return fmt.Errorf("Error: Response code %d not found among valid response codes", resp.StatusCode)
 		}
 
 	}
 
 	return nil
+}
+
+// Function checks if int is in slice of ints
+func intInSlice(s []int, e int) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,7 @@ type (
 		Template    string
 		Headers     []string
 		URLs        []string
+		ValidCodes  []int
 		Debug       bool
 		SkipVerify  bool
 	}
@@ -58,6 +59,15 @@ type (
 		Job    Job
 	}
 )
+
+func contains(s []int, e int) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
 
 func (p Plugin) Exec() error {
 	var (
@@ -136,6 +146,12 @@ func (p Plugin) Exec() error {
 
 		if err != nil {
 			fmt.Printf("Error: Failed to execute the HTTP request. %s\n", err)
+			return err
+		}
+
+		if len(p.Config.ValidCodes) > 0 && !contains(p.Config.ValidCodes, resp.StatusCode) {
+			err := fmt.Errorf("Response code %d not found among valid response codes", resp.StatusCode)
+			fmt.Printf("Error: %s\n", err)
 			return err
 		}
 


### PR DESCRIPTION
In this pull-request I wanted to introduce valid-response-codes settings, that returns failed result, when response code of webhook is not among the list of valid codes. For goals of backwards compatibility, if this slice of valid-response-codes is empty, check is not performed.