### PR TITLE
Add support for Authorization type Bearer Token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/drone-plugins/drone-webhook
 
-go 1.14
-
 require (
 	bou.ke/monkey v1.0.1 // indirect
 	github.com/aymerick/raymond v2.0.2+incompatible // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/drone-plugins/drone-webhook
 
+go 1.14
+
 require (
 	bou.ke/monkey v1.0.1 // indirect
 	github.com/aymerick/raymond v2.0.2+incompatible // indirect

--- a/main.go
+++ b/main.go
@@ -34,11 +34,17 @@ func main() {
 			Usage:  "password for basic auth",
 			EnvVar: "PLUGIN_PASSWORD,WEBHOOK_PASSWORD",
 		},
-                cli.StringFlag{
-			Name:   "token",
-			Usage:  "token for Bearer token auth",
-			EnvVar: "PLUGIN_TOKEN,WEBHOOK_TOKEN",
-                },
+		cli.StringFlag{
+			Name:   "token-value",
+			Usage:  "token value",
+			EnvVar: "PLUGIN_TOKEN_VALUE,WEBHOOK_TOKEN_VALUE",
+		},
+		cli.StringFlag{
+			Name:   "token-type",
+			Usage:  "type of token",
+			EnvVar: "PLUGIN_TOKEN_TYPE,WEBHOOK_TOKEN_TYPE",
+			Value:  "Bearer",
+		},
 		cli.StringFlag{
 			Name:   "content-type",
 			Usage:  "content type",
@@ -205,7 +211,8 @@ func run(c *cli.Context) error {
 			Method:          c.String("method"),
 			Username:        c.String("username"),
 			Password:        c.String("password"),
-			Token:           c.String("token"),
+			TokenValue:      c.String("token-value"),
+			TokenType:       c.String("token-type"),
 			ContentType:     c.String("content-type"),
 			Template:        c.String("template"),
 			Headers:         c.StringSlice("headers"),

--- a/main.go
+++ b/main.go
@@ -34,6 +34,11 @@ func main() {
 			Usage:  "password for basic auth",
 			EnvVar: "PLUGIN_PASSWORD,WEBHOOK_PASSWORD",
 		},
+                cli.StringFlag{
+			Name:   "token",
+			Usage:  "token for Bearer token auth",
+			EnvVar: "PLUGIN_TOKEN,WEBHOOK_TOKEN",
+                },
 		cli.StringFlag{
 			Name:   "content-type",
 			Usage:  "content type",
@@ -200,6 +205,7 @@ func run(c *cli.Context) error {
 			Method:          c.String("method"),
 			Username:        c.String("username"),
 			Password:        c.String("password"),
+			Token:           c.String("token"),
 			ContentType:     c.String("content-type"),
 			Template:        c.String("template"),
 			Headers:         c.StringSlice("headers"),

--- a/plugin.go
+++ b/plugin.go
@@ -43,7 +43,8 @@ type (
 		Method          string
 		Username        string
 		Password        string
-		Token           string
+		TokenValue      string
+		TokenType       string
 		ContentType     string
 		Template        string
 		Headers         []string
@@ -142,10 +143,9 @@ func (p Plugin) Exec() error {
 			req.SetBasicAuth(p.Config.Username, p.Config.Password)
 		}
 
-		if p.Config.Token != "" {
-			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", p.Config.Token))
+		if p.Config.TokenValue != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("%s %s", p.Config.TokenType, p.Config.TokenValue))
 		}
-
 
 		client := http.DefaultClient
 

--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,7 @@ type (
 		Method          string
 		Username        string
 		Password        string
+		Token           string
 		ContentType     string
 		Template        string
 		Headers         []string
@@ -140,6 +141,11 @@ func (p Plugin) Exec() error {
 		if p.Config.Username != "" && p.Config.Password != "" {
 			req.SetBasicAuth(p.Config.Username, p.Config.Password)
 		}
+
+		if p.Config.Token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", p.Config.Token))
+		}
+
 
 		client := http.DefaultClient
 


### PR DESCRIPTION
Some systems can not use basic authentication or need basic authentication to get token, then I add this feature support to use token directly. 
It possible to set via headers but in my case, I use an external secrets store (Kubernetes secret), it strips space from my secrets.