### PR TITLE
Add Stage parameters to webhook

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,6 +177,26 @@ func main() {
 			Usage:  "job started",
 			EnvVar: "DRONE_JOB_STARTED",
 		},
+		cli.StringFlag{
+			Name:   "stage.status",
+			Usage:  "stage status",
+			EnvVar: "DRONE_STAGE_STATUS",
+		},
+		cli.StringFlag{
+			Name:   "stage.name",
+			Usage:  "stage name",
+			EnvVar: "DRONE_STAGE_NAME",
+		},
+		cli.StringFlag{
+			Name:   "stage.type",
+			Usage:  "stage type",
+			EnvVar: "DRONE_STAGE_TYPE",
+		},
+		cli.StringFlag{
+			Name:   "stage.kind",
+			Usage:  "stage kind",
+			EnvVar: "DRONE_STAGE_KIND",
+		},
 	}
 
 	if _, err := os.Stat("/run/drone/env"); err == nil {
@@ -227,6 +247,12 @@ func run(c *cli.Context) error {
 			SkipVerify:      c.Bool("skip-verify"),
 			SignatureHeader: c.String("signature-header"),
 			SignatureSecret: c.String("signature-secret"),
+		},
+		Stage: Stage{
+			Type:   c.String("stage.type"),
+			Name:   c.String("stage.name"),
+			Status: c.String("stage.status"),
+			Kind:   c.String("stage.kind"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -24,10 +24,10 @@ type (
 	}
 
 	Stage struct {
-		Type	string	`json:"type"`
-		Kind	string	`json:"kind"`
-		Name 	string 	`json:"name"`
-		Status 	string 	`json:"status"`
+		Type   string `json:"type"`
+		Kind   string `json:"kind"`
+		Name   string `json:"name"`
+		Status string `json:"status"`
 	}
 
 	Build struct {
@@ -90,7 +90,7 @@ func (p Plugin) Exec() error {
 		data := struct {
 			Repo  Repo  `json:"repo"`
 			Build Build `json:"build"`
-			Stage Stage	`json:"stage"`
+			Stage Stage `json:"stage"`
 		}{p.Repo, p.Build, p.Stage}
 
 		if err := json.NewEncoder(&buf).Encode(&data); err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -23,6 +23,13 @@ type (
 		Name  string `json:"name"`
 	}
 
+	Stage struct {
+		Type	string	`json:"type"`
+		Kind	string	`json:"kind"`
+		Name 	string 	`json:"name"`
+		Status 	string 	`json:"status"`
+	}
+
 	Build struct {
 		Tag      string `json:"tag"`
 		Event    string `json:"event"`
@@ -64,6 +71,7 @@ type (
 		Repo   Repo
 		Build  Build
 		Config Config
+		Stage  Stage
 		Job    Job
 	}
 )
@@ -82,7 +90,8 @@ func (p Plugin) Exec() error {
 		data := struct {
 			Repo  Repo  `json:"repo"`
 			Build Build `json:"build"`
-		}{p.Repo, p.Build}
+			Stage Stage	`json:"stage"`
+		}{p.Repo, p.Build, p.Stage}
 
 		if err := json.NewEncoder(&buf).Encode(&data); err != nil {
 			fmt.Printf("Error: Failed to encode JSON payload. %s\n", err)


### PR DESCRIPTION
Stage information is needed to notify about for example specific pipeline success information in a case where one repository has multiple pipelines/stages.